### PR TITLE
Fix broken ampcode package

### DIFF
--- a/Formula/ampcode.rb
+++ b/Formula/ampcode.rb
@@ -12,10 +12,14 @@ class Ampcode < Formula
     regex(/"version":\s*"([^"]+)"/i)
   end
 
-  depends_on "node@20"
+  depends_on "node"
 
   def install
-    system "npm", "install", "--prefix", libexec, "."
-    bin.install_symlink libexec/"node_modules/.bin/amp"
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/amp --version")
   end
 end


### PR DESCRIPTION
It is currently in a state where it cannot be used even if installed. I have fixed it, so please merge it.

If you want to test it, use the command below:
```bash
brew install simnalamburt/ampcode/ampcode
```